### PR TITLE
feat: add -fno-gnu-unique flag to core_lib compilation options

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -9,3 +9,5 @@ target_include_directories(core_lib PUBLIC .)
 target_include_directories(core_lib PRIVATE ../shared)
 
 target_link_libraries(core_lib PRIVATE ${CMAKE_DL_LIBS})
+
+target_compile_options(core_lib PRIVATE -fno-gnu-unique)


### PR DESCRIPTION
This pull request introduces a small change to the `src/core/CMakeLists.txt` build configuration. The `core_lib` target now uses the `-fno-gnu-unique` compiler flag, which can affect symbol visibility and linking behavior.

- Build configuration:
  * Added `-fno-gnu-unique` to the compile options for `core_lib` in `src/core/CMakeLists.txt`.